### PR TITLE
Fix stopLoadingAnimation function

### DIFF
--- a/app/app-global-js/view-helpers.js
+++ b/app/app-global-js/view-helpers.js
@@ -53,6 +53,7 @@ function startLoadingAnimation() {
 */
 
 function stopLoadingAnimation() {
+  $('.loading-animation-container').remove();
   $('.loading-animation').remove();
 }
 


### PR DESCRIPTION
was previously getting stuck because it was only removing the class on
the loading animation div but not the loading-animation container, this
caused a bug where you couldn't then click on the button again because
the blue overlay of the loading-animation-container was blocking it
